### PR TITLE
Allowing @suppressWarnings

### DIFF
--- a/src/main/php/PHPMD/Node/Annotation.php
+++ b/src/main/php/PHPMD/Node/Annotation.php
@@ -27,7 +27,7 @@ class Annotation
     /**
      * Name of the suppress warnings annotation.
      */
-    const SUPPRESS_ANNOTATION = 'SuppressWarnings';
+    const SUPPRESS_ANNOTATION = 'suppressWarnings';
 
     /**
      * The annotation name.
@@ -63,7 +63,7 @@ class Annotation
      */
     public function suppresses(Rule $rule)
     {
-        if ($this->name === self::SUPPRESS_ANNOTATION) {
+        if (lcfirst($this->name) === self::SUPPRESS_ANNOTATION) {
             return $this->isSuppressed($rule);
         }
         return false;

--- a/src/test/php/PHPMD/Node/AnnotationTest.php
+++ b/src/test/php/PHPMD/Node/AnnotationTest.php
@@ -71,6 +71,17 @@ class AnnotationTest extends AbstractTest
     }
 
     /**
+     * testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst
+     *
+     * @return void
+     */
+    public function testAnnotationReturnsTrueWhenSuppressWarningContainsWithPHPMDLCFirst()
+    {
+        $annotation = new Annotation('suppressWarnings', 'PHPMD');
+        $this->assertTrue($annotation->suppresses($this->getRuleMock()));
+    }
+
+    /**
      * testAnnotationReturnsTrueWhenSuppressWarningContainsPMDPlusRuleName
      *
      * @return void

--- a/src/test/php/PHPMD/Node/MethodNodeTest.php
+++ b/src/test/php/PHPMD/Node/MethodNodeTest.php
@@ -137,6 +137,20 @@ class MethodNodeTest extends AbstractTest
     }
 
     /**
+     * testHasSuppressWarningsIgnoresCaseFirstLetter
+     *
+     * @return void
+     */
+    public function testHasSuppressWarningsIgnoresCaseFirstLetter()
+    {
+        $rule = $this->getRuleMock();
+        $rule->setName('FooBar');
+
+        $method = $this->getMethod();
+        $this->assertTrue($method->hasSuppressWarningsAnnotationFor($rule));
+    }
+
+    /**
      * testIsDeclarationReturnsTrueForMethodDeclaration
      *
      * @return void

--- a/src/test/resources/files/Node/MethodNode/testHasSuppressWarningsIgnoresCaseFirstLetter.php
+++ b/src/test/resources/files/Node/MethodNode/testHasSuppressWarningsIgnoresCaseFirstLetter.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of PHP Mess Detector.
+ *
+ * Copyright (c) Manuel Pichler <mapi@phpmd.org>.
+ * All rights reserved.
+ *
+ * Licensed under BSD License
+ * For full copyright and license information, please see the LICENSE file.
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @author Manuel Pichler <mapi@phpmd.org>
+ * @copyright Manuel Pichler. All rights reserved.
+ * @license https://opensource.org/licenses/bsd-license.php BSD License
+ * @link http://phpmd.org/
+ */
+
+class testHasSuppressWarningsIgnoresCaseFirstLetterClass
+{
+    /**
+     * @suppressWarnings("PHPMD.FooBar")
+     */
+    function testHasSuppressWarningsIgnoresCaseFirstLetter()
+    {
+
+    }
+}
+
+class testHasSuppressWarningsIgnoresCaseFirstLetterClass
+{
+    /**
+     * @suppressWarnings("PHPMD.FooBar")
+     */
+    function testHasSuppressWarningsIgnoresCaseFirstLetter()
+    {
+
+    }
+}


### PR DESCRIPTION
This commit brings the suppress warnings annotations into line with other
common PHP annotations, allowing the first letter to be lowercase  so that
both upper (@SuppressWarnings) and lower (@suppressWarnings) camel case are
accepted.